### PR TITLE
Use Node.js 20.12.2 instead of 'latest'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: "setup npm"
         uses: actions/setup-node@v4
         with:
-          node-version: 'latest'
+          node-version: '20.12.2'
           cache: 'npm'
           cache-dependency-path: docs-site/package-lock.json
 


### PR DESCRIPTION
Works around https://github.com/nodejs/node/pull/52708 / https://github.com/gulpjs/vinyl-fs/issues/350 by reverting to previous LTS version.

@gpx1000 this addresses the build problem so I'm going to merge it and for the time being, CI will stay on node 20.12.2.