### PR TITLE
Remove "Edit this Page" link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ prep-tutorial:
 	make -C Vulkan-Tutorial/antora setup_tutorial
 
 # Build Antora site
+# CI is needed as an environment variable which helps cause suppression
+# of the "Edit this Page" link otherwise generated.
+export CI = true
 build-site:
 	cd docs-site && npx antora antora-playbook.yml --stacktrace
 

--- a/docs-site/antora-playbook.yml
+++ b/docs-site/antora-playbook.yml
@@ -5,8 +5,12 @@ site:
   title: Vulkan Documentation Project
   start_page: spec::index.adoc
 content:
-# Use worktree for guide and spec - local file URL, HEAD branch, not
-# specifying .git directory
+  # Do not include 'Edit this Page' link per
+  # https://docs.antora.org/antora/latest/playbook/content-edit-url/#disable-edit-u
+  # Must also set environment variable CI=true for this to work
+  edit_url: false
+  # Use worktree for guide and spec - local file URL, HEAD branch, not
+  # specifying .git directory
   sources:
     - url: ../Vulkan-Guide
       branches: HEAD


### PR DESCRIPTION
This was surprisingly tricky, mostly because the docs are a bit opaque. To make this work we need to set the 'edit_url' content: property in the playbook, AND to set the CI environment variable to 'true' (even when running locally). See

https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Can't.20hide.20'Edit.20this.20Page'.20Link

I modified the Makefile which can be used for local builds accordingly and hopefully, Actions CI will set the variable. If not I'll modify the ci.yml as well.