### PR TITLE
Update Vulkan-Docs site build rules to match changes in that repo's Makefiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: KhronosGroup/Vulkan-Docs
           path: ./Vulkan-Docs
-          ref: antora-makefile
+          ref: main
           submodules: recursive
 
       - name: "Checkout Vulkan Samples"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: KhronosGroup/Vulkan-Docs
           path: ./Vulkan-Docs
-          ref: main
+          ref: antora-makefile
           submodules: recursive
 
       - name: "Checkout Vulkan Samples"

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ prep-sources: prep-docs prep-guide prep-samples prep-tutorial
 # Prepare Vulkan-Docs
 GENPATH = Vulkan-Docs/gen
 prep-docs:
-	make -C Vulkan-Docs setup_antora
+	cd Vulkan-Docs && ./makeSpec -clean -spec all setup_antora
 	cp $(GENPATH)/apimap.cjs \
 	   $(GENPATH)/pageMap.cjs \
 	   $(GENPATH)/xrefMap.cjs \

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,14 @@ init: subrepos
 	    (echo Installing node modules in $$dir: && cd $$dir && npm install) ; \
 	done
 
-subrepos: $(REPONAMES)
+subrepos:
 	for repo in $(REPONAMES) ; do \
 	    echo Cloning $$repo && \
-	    test -d $$repo || git clone git@github.com:KhronosGroup/$$repo.git ; \
+	    if test -d $$repo ; then \
+		echo "Not cloning repo $$repo, already exists" ; \
+	    else \
+	    git clone git@github.com:KhronosGroup/$$repo.git ; \
+	    fi ; \
 	done
 
 # Build UI bundle
@@ -65,12 +69,12 @@ build-ui:
 prep-sources: prep-docs prep-guide prep-samples prep-tutorial
 
 # Prepare Vulkan-Docs
-GENPATH = Vulkan-Docs/antora/spec/modules/ROOT/partials/gen
+GENPATH = Vulkan-Docs/gen
 prep-docs:
-	make -C Vulkan-Docs -f antora/Makefile clean setup
+	make -C Vulkan-Docs setup_antora
 	cp $(GENPATH)/apimap.cjs \
 	   $(GENPATH)/pageMap.cjs \
-	   Vulkan-Docs/antora/spec/xrefMap.cjs \
+	   $(GENPATH)/xrefMap.cjs \
 	   docs-site/js/
 
 prep-guide:


### PR DESCRIPTION
Pairs with https://github.com/KhronosGroup/Vulkan-Docs/pull/2450 . Both PRs must be merged to allow building of the site to continue working - merging just one will cause problems.

There was a temporary patch to ci.yml to use the source branch for  https://github.com/KhronosGroup/Vulkan-Docs/pull/2450, now reverted to 'main' since that PR is merged.