### PR TITLE
Changes to incorporate GLSL into site build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
           ref: main
           submodules: recursive
 
+      - name: "checkout GLSL"
+        uses: actions/checkout@v4
+        with:
+          repository: KhronosGroup/GLSL
+          path: ./GLSL
+          ref: main
+          submodules: recursive
+
       - name: "checkout Vulkan Guide"
         uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@
 #   This Makefile itself does no branch selection.
 # 'build-ui' - builds the Antora UI package.
 # 'prep-sources' - prepare each repository's files for Antora.
-# This has four subtargets for the separate repos:
+# This has subtargets for the separate repos:
 #   'prep-docs' - Vulkan-Docs (specification and feature description
 #	components
+#   'prep-glsl' - OpenGL Shading Language specification
 #   'prep-guide' - Vulkan Guide
 #   'prep-samples' - Vulkan Samples
 #   'prep-tutorials' - Vulkan Tutorials
@@ -28,7 +29,7 @@
 # 'clean' - cleans the Antora site
 
 # UI and component repositories which must exist as subdirectories to build
-REPONAMES = antora-ui-khronos Vulkan-Guide Vulkan-Samples Vulkan-Tutorial Vulkan-Docs
+REPONAMES = antora-ui-khronos GLSL Vulkan-Guide Vulkan-Samples Vulkan-Tutorial Vulkan-Docs
 
 # Directories (mostly repos) with their own npm infrastructure
 DIRSWITHNODE = antora-ui-khronos docs-site Vulkan-Docs
@@ -52,9 +53,11 @@ subrepos:
 	    if test -d $$repo ; then \
 		echo "Not cloning repo $$repo, already exists" ; \
 	    else \
-	    git clone git@github.com:KhronosGroup/$$repo.git ; \
+		git clone git@github.com:KhronosGroup/$$repo.git ; \
 	    fi ; \
 	done
+	# Temporarily use development main branch
+	cd GLSL && git switch antora
 
 # Build UI bundle
 build-ui:
@@ -76,6 +79,9 @@ prep-docs:
 	   $(GENPATH)/pageMap.cjs \
 	   $(GENPATH)/xrefMap.cjs \
 	   docs-site/js/
+
+prep-glsl:
+	make -C GLSL clean setup_antora
 
 prep-guide:
 	make -C Vulkan-Guide -f antora/Makefile clean setup

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,6 @@ subrepos:
 		git clone git@github.com:KhronosGroup/$$repo.git ; \
 	    fi ; \
 	done
-	# Temporarily use development main branch
-	cd GLSL && git switch antora
 
 # Build UI bundle
 build-ui:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ build-ui:
 	cp antora-ui-khronos/build/ui-bundle.zip docs-site
 
 # Prepare component antora sources
-prep-sources: prep-docs prep-guide prep-samples prep-tutorial
+prep-sources: prep-glsl prep-guide prep-samples prep-tutorial prep-docs
 
 # Prepare Vulkan-Docs
 GENPATH = Vulkan-Docs/antora/spec/modules/ROOT/partials/gen

--- a/docs-site/antora-playbook.yml
+++ b/docs-site/antora-playbook.yml
@@ -15,6 +15,9 @@ content:
     - url: ../Vulkan-Guide
       branches: HEAD
       start_path: antora
+    - url: ../GLSL
+      branches: HEAD
+      start_path: antora/glsl
     - url: ../Vulkan-Docs
       branches: HEAD
       start_paths: antora/spec, antora/features

--- a/docs-site/antora-playbook.yml
+++ b/docs-site/antora-playbook.yml
@@ -17,7 +17,7 @@ content:
       start_path: antora
     - url: ../GLSL
       branches: HEAD
-      start_path: antora/glsl
+      start_path: antora
     - url: ../Vulkan-Docs
       branches: HEAD
       start_paths: antora/spec, antora/features


### PR DESCRIPTION
This is ready to go. CI will probably *not* succeed at present since adding the GLSL module currently requires building out of a non-default branch of that repository, but it builds locally aside from some very minor asciidoc tweaks I will do before publishing.

It will need to be merged together with https://github.com/KhronosGroup/GLSL/pull/266 . There will also need to be a change in the UI repository to add GLSL to the navbar pulldowns.