### PR TITLE
Use the same protocol for the UI submodule as for the repository itself

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "antora-ui-khronos"]
+	path = antora-ui-khronos
+	url = ../antora-ui-khronos

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "antora-ui-khronos"]
-	path = antora-ui-khronos
-	url = https://github.com/KhronosGroup/antora-ui-khronos.git


### PR DESCRIPTION
Fixes #124 . Also brings the submodule state up to date, whence it was pointing to a commit from January.

Note: I have not (and really cannot) fully test this against a repository cloned with HTTPS, because I cannot work that way due to github restrictions (possibly due to my being a repo admin there). This follows generally speaking discussion at https://stackoverflow.com/questions/6031494/git-submodules-and-ssh-access#6031607

The key issue is that once you have created a submodule, its state persists in at least three places: .gitmodules, the submodule .git directory under .git/modules/antora-ui-khronos, and the submodule directory itself. Removing the submodule - including its .gitmodules entry - *does not* remove some or all of the .git state in the parent repository, which will pop back up like a bad penny. So I made it work by cloning the parent *without* submodule recursion, creating this branch and making the .gitmodules changes, and *only then* going into the submodule:

```
git clone git@github.com:KhronosGroup/Vulkan-Site.git site
cd site
git switch -c ssh-submod
git rm antora-ui-khronos
git commit -m "Remove existing antora-ui-khronos module with HTTPS URL"

git submodule add ../antora-ui-khronos antora-ui-khronos
git commit -m "Add antora-ui-khronos modules with relative URL"
git push --set-upstream origin ssh-submod
```

Once that is done, initializing and updating the submodule appears to proceed over the same protocol as the parent repository. And at that point, and only that point, it became possible for me to create local changes in a branch in the submodule, then push them to the submodule's repository on github.