### PR TITLE
Fix history building up in the gh-pages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
           publish_dir: docs-site/build/site
           destination_dir: ${{ (github.event.inputs.PR_Number != '' && format('PR-{0}', github.event.inputs.PR_Number)) || (github.event.pull_request && format('PR-{0}', github.event.number)) || '' }}
           keep_files: true
+          force_orphan: true
 
       - name: Comment on PR
         if: github.event.pull_request && success()


### PR DESCRIPTION
Add force_orphan option to GitHub Pages deployment
Enables the force_orphan flag in the peaceiris/actions-gh-pages action to ensure clean deployments without maintaining full commit history in the gh-pages branch.