### PR TITLE
Add GLSL Extensions component

### DIFF
--- a/docs-site/antora-playbook.yml
+++ b/docs-site/antora-playbook.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 The Khronos Group Inc.
+# Copyright 2022-2026 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 site:
@@ -17,7 +17,7 @@ content:
       start_path: antora
     - url: ../GLSL
       branches: HEAD
-      start_path: antora
+      start_paths: antora, antora/glslext
     - url: ../Vulkan-Docs
       branches: HEAD
       start_paths: antora/spec, antora/features, antora/refpages

--- a/package-lock.json
+++ b/package-lock.json
@@ -2456,9 +2456,9 @@
       "license": "MIT"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "dev": true,
       "funding": [
         {

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -38,6 +38,7 @@
             <a class="navbar-item" href="{{siteRootPath}}/guide/latest/index.html">Vulkan Guide</a>
             <a class="navbar-item" href="{{siteRootPath}}/samples/latest/README.html">Vulkan Samples</a>
             <a class="navbar-item" href="{{siteRootPath}}/tutorial/latest/index.html">Vulkan Tutorial</a>
+            <a class="navbar-item" href="{{siteRootPath}}/glslext/latest/index.html">GLSL Extensions</a>
             <a class="navbar-item" href="https://www.youtube.com/c/vulkan">YouTube</a>
             <a class="navbar-item" href="https://vulkan.org">More Info at Vulkan.org</a>
           </div>


### PR DESCRIPTION
Requires https://github.com/KhronosGroup/GLSL/pull/321 (edit: which is now merged).
A tweak to the main site index page, which is in Vulkan-Docs, will be needed after this is merged so the new component is described.

We might also want to tweak the GLSL specification component index similarly.

An update to the CI manual run selector scripts is probably called for, so the glslext component can be turned off. @gpx1000 please advise on that.