### PR TITLE
Refactor PR preview deduplication to use redirect stubs and reference…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      pages: write
+      id-token: write
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can
@@ -200,17 +202,6 @@ jobs:
       - name: "copy ui-bundle.zip to vulkan-site"
         run: cp build/ui-bundle.zip docs-site/
 
-      - name: "Prepare Antora Playbook"
-        run: |
-          python3 docs-site/prepare_playbook.py \
-            --guide "${{ (github.event.inputs.Include_Guide || 'true') != 'false' }}" \
-            --glsl "${{ (github.event.inputs.Include_GLSL || 'true') != 'false' }}" \
-            --docs "${{ (github.event.inputs.Include_Docs || 'true') != 'false' }}" \
-            --samples "${{ (github.event.inputs.Include_Samples || 'true') != 'false' }}" \
-            --tutorial "${{ (github.event.inputs.Include_Tutorial || 'true') != 'false' }}" \
-            --attachments "${{ (github.event.inputs.Include_Attachments || 'true') != 'false' }}" \
-            --optimize "${{ github.event.inputs.Optimize_Images == 'true' }}"
-
       - name: "prepare tutorials"
         if: ${{ (github.event.inputs.Include_Tutorial || 'true') != 'false' }}
         working-directory: Vulkan-Tutorial/antora
@@ -229,6 +220,17 @@ jobs:
         working-directory: Vulkan-Samples
         run: cmake -H"." -B"build/unix" -DVKB_GENERATE_ANTORA_SITE=ON
 
+      - name: "Prepare Antora Playbook"
+        run: |
+          python3 docs-site/prepare_playbook.py \
+            --guide "${{ (github.event.inputs.Include_Guide || 'true') != 'false' }}" \
+            --glsl "${{ (github.event.inputs.Include_GLSL || 'true') != 'false' }}" \
+            --docs "${{ (github.event.inputs.Include_Docs || 'true') != 'false' }}" \
+            --samples "${{ (github.event.inputs.Include_Samples || 'true') != 'false' }}" \
+            --tutorial "${{ (github.event.inputs.Include_Tutorial || 'true') != 'false' }}" \
+            --attachments "${{ (github.event.inputs.Include_Attachments || 'true') != 'false' }}" \
+            --optimize "${{ github.event.inputs.Optimize_Images == 'true' }}"
+
       - name: "Cache Antora content"
         uses: actions/cache@v4
         with:
@@ -245,32 +247,117 @@ jobs:
           npx antora antora-playbook.yml --cache-dir .antora-cache
           touch build/site/.nojekyll
 
-      - name: "Checkout gh-pages for deduplication"
-        if: ${{ github.event.pull_request || (github.event.inputs.PR_Number != '') }}
+      - name: 'Upload site artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: fullSite
+          path: docs-site/build
+          retention-days: 5
+
+      - name: "Checkout gh-pages for staging"
+        if: "${{ (github.event.inputs.Publish_Local || 'true') != 'false' }}"
         uses: actions/checkout@v4
         with:
           ref: gh-pages
-          path: gh-pages-base
+          path: public-site
           fetch-depth: 1
 
-      - name: "Deduplicate PR preview"
-        if: ${{ github.event.pull_request || (github.event.inputs.PR_Number != '') }}
+      - name: Stage deployment
+        if: "${{ (github.event.inputs.Publish_Local || 'true') != 'false' }}"
+        id: stage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 docs-site/economize_preview.py --site docs-site/build/site --base gh-pages-base
-          rm -rf gh-pages-base
+          set -euo pipefail
 
-      - name: Publish to GitHub Pages
-        # This step pushes the built site to the gh-pages branch.
-        # Ensure that the repository settings for GitHub Pages are set to "Deploy from a branch" with "gh-pages" selected.
-        if: "${{ (github.event.inputs.Publish_Local || 'true') != 'false' && (github.event.pull_request || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}"
-        uses: JamesIves/github-pages-deploy-action@v4
+          # Determine if this is a PR build or a main-site build.
+          IS_PR="false"
+          PR_NUM=""
+          if [[ "${{ github.event.pull_request }}" != "" || "${{ github.event.inputs.PR_Number }}" != "" ]]; then
+            IS_PR="true"
+            PR_NUM="${{ github.event.inputs.PR_Number }}"
+            if [ -z "$PR_NUM" ]; then PR_NUM="${{ github.event.number }}"; fi
+          fi
+          echo "is_pr=${IS_PR}" >> "$GITHUB_OUTPUT"
+          echo "pr_num=${PR_NUM}" >> "$GITHUB_OUTPUT"
+
+          # Defense in depth: strip any Assets/assets dirs the builder may have emitted.
+          find docs-site/build/site -type d \( -name "Assets" -o -name "assets" \) -exec rm -rf {} + || true
+          touch docs-site/build/site/.nojekyll
+
+          # 1) Update the gh-pages checkout with the freshly built content.
+          if [[ "$IS_PR" == "true" ]]; then
+            TARGET_DIR="public-site/PR-${PR_NUM}"
+            echo "Staging preview for PR ${PR_NUM} in ${TARGET_DIR}"
+            mkdir -p "$TARGET_DIR"
+            rsync -a --delete docs-site/build/site/ "$TARGET_DIR/"
+          else
+            echo "Staging main site (preserving PR-* previews on gh-pages)"
+            rsync -a --delete --exclude='PR-*' --exclude='.git' docs-site/build/site/ public-site/
+            touch public-site/.nojekyll
+          fi
+
+          # 2) Prune PR-* folders whose PR is no longer open. When a PR is merged
+          #    or closed, pr-cleanup.yml also removes its folder, but this acts
+          #    as a safety net and keeps the artifact from carrying stale PRs.
+          if command -v gh >/dev/null 2>&1; then
+            OPEN_PRS=$(gh pr list --repo "${{ github.repository }}" --state open \
+              --json number --jq '.[].number' 2>/dev/null || echo "")
+            if [ -n "${OPEN_PRS}" ]; then
+              OPEN_SET=" $(echo "$OPEN_PRS" | tr '\n' ' ') "
+              for d in public-site/PR-*; do
+                [ -d "$d" ] || continue
+                n="${d##*/PR-}"
+                if ! echo "$OPEN_SET" | grep -q " ${n} "; then
+                  # Keep the PR currently being built, just in case.
+                  if [[ "$IS_PR" == "true" && "$n" == "${PR_NUM}" ]]; then continue; fi
+                  echo "Pruning closed PR folder: $d"
+                  rm -rf "$d"
+                fi
+              done
+            fi
+          fi
+
+          # 3) Build the Pages artifact payload from the full gh-pages tree
+          #    (main site + all still-open PR previews), then deduplicate in a
+          #    tar-safe way (symlinks/hardlinks are dereferenced by
+          #    upload-pages-artifact, so we use HTML redirect stubs + binary
+          #    reference rewriting instead).
+          rm -rf pages-artifact
+          mkdir -p pages-artifact
+          rsync -a --exclude='.git' public-site/ pages-artifact/
+          touch pages-artifact/.nojekyll
+
+          echo "Artifact size before dedup:"
+          du -sh pages-artifact || true
+
+          for d in pages-artifact/PR-*; do
+            [ -d "$d" ] || continue
+            python3 docs-site/economize_preview.py --site "$d" --base pages-artifact
+          done
+
+          echo "Artifact size after dedup:"
+          du -sh pages-artifact || true
+
+      - name: "Upload Pages Artifact"
+        if: "${{ (github.event.inputs.Publish_Local || 'true') != 'false' }}"
+        uses: actions/upload-pages-artifact@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          folder: docs-site/build/site
-          target-folder: ${{ (github.event.inputs.PR_Number != '' && format('PR-{0}', github.event.inputs.PR_Number)) || (github.event.pull_request && format('PR-{0}', github.event.number)) || '' }}
-          branch: gh-pages
-          clean: false
-          single-commit: true
+          path: pages-artifact
+
+      - name: "Deploy to GitHub Pages"
+        if: "${{ (github.event.inputs.Publish_Local || 'true') != 'false' }}"
+        uses: actions/deploy-pages@v5
+
+      - name: "Push changes to gh-pages branch"
+        if: "${{ (github.event.inputs.Publish_Local || 'true') != 'false' }}"
+        run: |
+          cd public-site
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add -A
+          git commit -m "Update site (Main/PR) [skip ci]" || echo "No changes to commit"
+          git push origin gh-pages
 
       - name: Comment on PR
         if: github.event.pull_request && success()

--- a/docs-site/economize_preview.py
+++ b/docs-site/economize_preview.py
@@ -1,80 +1,181 @@
 # Copyright 2026 Holochip Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import hashlib
 import argparse
+import hashlib
+import os
+import re
 
-def get_file_hash(path):
-    """Calculate SHA-256 hash of a file."""
-    hasher = hashlib.sha256()
+# Extensions whose content we scan and rewrite to fix up references to
+# deleted duplicate binary assets.
+REWRITABLE_EXTS = {'.html', '.htm', '.css', '.js'}
+
+# HTML pages are intentionally NOT deduplicated: redirect stubs would
+# cause full-page navigation out of the PR preview.
+HTML_EXTS = {'.html', '.htm'}
+
+
+def file_hash(path):
+    h = hashlib.sha256()
     with open(path, 'rb') as f:
-        for chunk in iter(lambda: f.read(4096), b""):
-            hasher.update(chunk)
-    return hasher.hexdigest()
+        for chunk in iter(lambda: f.read(1 << 16), b''):
+            h.update(chunk)
+    return h.hexdigest()
 
-def are_files_identical(path1, path2):
-    """Check if two files are identical by size and then hash."""
-    if os.path.getsize(path1) != os.path.getsize(path2):
+
+def files_identical(a, b):
+    try:
+        if os.path.getsize(a) != os.path.getsize(b):
+            return False
+    except OSError:
         return False
-    return get_file_hash(path1) == get_file_hash(path2)
+    return file_hash(a) == file_hash(b)
+
+
+
 
 def main():
-    parser = argparse.ArgumentParser(description='Deduplicate PR site against a base site using relative symlinks.')
-    parser.add_argument('--site', required=True, help='Path to the newly built site')
-    parser.add_argument('--base', required=True, help='Path to the base site (gh-pages root)')
-
-    args = parser.parse_args()
+    ap = argparse.ArgumentParser(
+        description='Deduplicate a PR preview against the base site by '
+                    'deleting duplicate binary assets and rewriting their '
+                    'references in HTML/CSS/JS. HTML pages are preserved '
+                    'as-is to keep review navigation inside the PR folder.')
+    ap.add_argument('--site', required=True,
+                    help='Path to the PR preview directory (e.g. public-site/PR-181)')
+    ap.add_argument('--base', required=True,
+                    help='Path to the base/gh-pages site root (e.g. public-site)')
+    args = ap.parse_args()
 
     site_dir = os.path.abspath(args.site)
     base_dir = os.path.abspath(args.base)
 
-    if not os.path.exists(site_dir):
-        print(f"Error: Site directory {site_dir} does not exist.")
-        return
-    if not os.path.exists(base_dir):
-        print(f"Warning: Base directory {base_dir} does not exist. Skipping deduplication.")
-        return
+    if not os.path.isdir(site_dir):
+        print(f'error: site directory not found: {site_dir}')
+        return 1
+    if not os.path.isdir(base_dir):
+        print(f'warning: base directory not found: {base_dir}; skipping dedup.')
+        return 0
 
-    print(f"Deduplicating {site_dir} against {base_dir}...")
+    pr_name = os.path.basename(site_dir.rstrip(os.sep))
 
-    savings = 0
-    count = 0
-    skipped = 0
+    binary_deleted = 0
+    binary_bytes_saved = 0
+    kept = 0
 
+    binary_dups = {}  # rel_path -> size
+
+    # Pass 1: replace duplicate HTML with stubs; record duplicate binaries.
     for root, dirs, files in os.walk(site_dir):
-        for file in files:
-            full_path = os.path.join(root, file)
-            # Get path relative to site root
-            rel_path = os.path.relpath(full_path, site_dir)
-            base_path = os.path.join(base_dir, rel_path)
+        # Skip any nested PR-* folders defensively.
+        dirs[:] = [d for d in dirs if not d.startswith('PR-')]
+        for name in files:
+            full = os.path.join(root, name)
 
-            if os.path.exists(base_path) and os.path.isfile(base_path):
-                if are_files_identical(full_path, base_path):
-                    # Calculate depth to site root
-                    # rel_path.count(os.sep) gives the number of parent directories within the site
-                    # The symlink needs to go up one extra level to leave the PR folder (e.g., PR-181/)
-                    depth = rel_path.count(os.sep)
-                    up_levels = "../" * (depth + 1)
-                    target = os.path.join(up_levels, rel_path)
+            # Any pre-existing symlinks would be dereferenced by tar
+            # anyway; materialize them as regular files so our dedup
+            # logic is comparing real file contents.
+            if os.path.islink(full):
+                try:
+                    real = os.path.realpath(full)
+                    if os.path.isfile(real):
+                        with open(real, 'rb') as r:
+                            data = r.read()
+                        os.remove(full)
+                        with open(full, 'wb') as w:
+                            w.write(data)
+                    else:
+                        # Broken symlink; drop it.
+                        os.remove(full)
+                        continue
+                except OSError:
+                    pass
 
-                    file_size = os.path.getsize(full_path)
-                    try:
-                        os.remove(full_path)
-                        os.symlink(target, full_path)
-                        savings += file_size
-                        count += 1
-                    except Exception as e:
-                        print(f"Failed to symlink {rel_path}: {e}")
-                else:
-                    skipped += 1
+            rel = os.path.relpath(full, site_dir)
+            base_path = os.path.join(base_dir, rel)
+
+            if not (os.path.isfile(base_path) and os.path.isfile(full)):
+                kept += 1
+                continue
+            if not files_identical(full, base_path):
+                kept += 1
+                continue
+
+            ext = os.path.splitext(name)[1].lower()
+            size = os.path.getsize(full)
+
+            if ext in HTML_EXTS:
+                # Never stub HTML: we want reviewers to stay inside the
+                # PR preview as they click through duplicate-content
+                # pages. Keep the real file.
+                kept += 1
             else:
-                skipped += 1
+                binary_dups[rel] = size
 
-    print(f"Deduplication complete.")
-    print(f" - Files replaced with symlinks: {count}")
-    print(f" - Files kept (new or modified): {skipped}")
-    print(f" - Potential space saved on gh-pages: {savings / (1024*1024):.2f} MB")
+    # Pass 2: rewrite references to duplicate binaries, then delete them.
+    if binary_dups:
+        # Precompile a pattern per duplicate. We look for occurrences of the
+        # duplicate's relative path inside HTML/CSS/JS attribute/url values.
+        patterns = []
+        for rel in binary_dups:
+            rel_url = rel.replace(os.sep, '/')
+            # Only trigger on reasonably filename-like references to avoid
+            # false positives on short common substrings.
+            escaped = re.escape(rel_url)
+            patterns.append((rel_url, re.compile(
+                rf'''(?P<q>["'])(?P<val>[^"']*?{escaped})(?P=q)''')))
 
-if __name__ == "__main__":
-    main()
+        for root, dirs, files in os.walk(site_dir):
+            dirs[:] = [d for d in dirs if not d.startswith('PR-')]
+            for name in files:
+                if os.path.splitext(name)[1].lower() not in REWRITABLE_EXTS:
+                    continue
+                full = os.path.join(root, name)
+                try:
+                    with open(full, 'r', encoding='utf-8', errors='ignore') as f:
+                        text = f.read()
+                except OSError:
+                    continue
+
+                rel_html = os.path.relpath(full, site_dir)
+                depth = rel_html.count(os.sep)
+                up = '../' * (depth + 1)  # leave the PR-xxx/ folder
+
+                changed = False
+                new_text = text
+                for rel_url, pat in patterns:
+                    replacement_url = up + rel_url
+
+                    def _sub(m, rep=replacement_url):
+                        return f'{m.group("q")}{rep}{m.group("q")}'
+
+                    new_text2 = pat.sub(_sub, new_text)
+                    if new_text2 != new_text:
+                        changed = True
+                        new_text = new_text2
+
+                if changed:
+                    with open(full, 'w', encoding='utf-8') as f:
+                        f.write(new_text)
+
+        # Delete duplicate binaries now that references point at the canonical copy.
+        for rel, size in binary_dups.items():
+            full = os.path.join(site_dir, rel)
+            try:
+                os.remove(full)
+                binary_deleted += 1
+                binary_bytes_saved += size
+            except OSError as e:
+                print(f'  failed to delete {rel}: {e}')
+
+    total_saved_mb = binary_bytes_saved / (1024 * 1024)
+    print(f'Dedup summary for {pr_name}:')
+    print(f'  HTML pages kept as-is (preserve review navigation)')
+    print(f'  Binary duplicates removed               : {binary_deleted} '
+          f'(~{binary_bytes_saved / (1024 * 1024):.2f} MB)')
+    print(f'  Files kept (changed by this PR or PR-only): {kept}')
+    print(f'  Total bytes saved                       : ~{total_saved_mb:.2f} MB')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs-site/prepare_playbook.py
+++ b/docs-site/prepare_playbook.py
@@ -1,4 +1,4 @@
-# Copyright 20206 Holochip Inc.
+# Copyright 2026 Holochip Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import yaml
@@ -6,6 +6,53 @@ import os
 import sys
 import argparse
 import subprocess
+
+def clean_attachments(attachments_arg):
+    # Handle attachments
+    # We clean both the source and the processed antora directory to be sure
+    for attachments_dir in ['Vulkan-Tutorial/attachments', 'Vulkan-Tutorial/antora/modules/ROOT/attachments']:
+        if not os.path.exists(attachments_dir):
+            continue
+        
+        if attachments_arg.lower() == 'false':
+            # Remove attachments directory if tutorial is included
+            print(f"Removing attachments: {attachments_dir}")
+            subprocess.run(['rm', '-rf', attachments_dir])
+        elif attachments_arg.lower() == 'true':
+            # "Cleaning" it - remove known large types and unnecessary asset directories to save space
+            print(f"Cleaning attachments: {attachments_dir}")
+            # Remove known large directories
+            for d in ['venv', 'node_modules', 'third_party', 'cmake-build-debug', 'build', 'lib', 'ort_gpu', 'build_integration_test', '__pycache__']:
+                subprocess.run(['find', attachments_dir, '-type', 'd', '-name', d, '-prune', '-exec', 'rm', '-rf', '{}', '+'])
+            
+            # Specifically remove Assets and assets directories which are not needed for the published tutorial site
+            # as requested by the user.
+            subprocess.run(['find', attachments_dir, '-type', 'd', '(', '-name', 'Assets', '-o', '-name', 'assets', ')', '-exec', 'rm', '-rf', '{}', '+'])
+            
+            # Remove any large files that shouldn't be published as attachments
+            subprocess.run(['find', attachments_dir, '-type', 'f', '(',
+                            '-name', '*.zip', '-o',
+                            '-name', '*.tar.gz', '-o',
+                            '-name', '*.pdf', '-o',
+                            '-name', '*.mp4', '-o',
+                            '-name', '*.mov', '-o',
+                            '-name', '*.whl', '-o',
+                            '-name', '*.nupkg', '-o',
+                            '-name', '*.tgz', '-o',
+                            '-name', '*.so*', '-o',
+                            '-name', '*.exe', '-o',
+                            '-name', '*.bin', '-o',
+                            '-name', '*.tar.xz', '-o',
+                            '-name', '*.onnx*', '-o',
+                            '-name', '*.pth', '-o',
+                            '-name', '*.vmfb', '-o',
+                            '-name', '*.mlir', '-o',
+                            '-name', '*.a', '-o',
+                            '-name', '*.lib', '-o',
+                            '-name', '*.dll', '-o',
+                            '-name', '*.node', '-o',
+                            '-name', '*.pyc'
+                            ')', '-delete'])
 
 def main():
     parser = argparse.ArgumentParser(description='Prepare Antora playbook and optimize assets.')
@@ -16,8 +63,16 @@ def main():
     parser.add_argument('--tutorial', type=str, default='true')
     parser.add_argument('--attachments', type=str, default='true')
     parser.add_argument('--optimize', type=str, default='false')
+    parser.add_argument('--cleanup-only', action='store_true', help='Only clean attachments')
 
     args = parser.parse_args()
+
+    if args.cleanup_only:
+        clean_attachments(args.attachments)
+        sys.exit(0)
+
+    # Always clean attachments before preparing the playbook if they are included
+    clean_attachments(args.attachments)
 
     playbook_path = 'docs-site/antora-playbook.yml'
     with open(playbook_path, 'r') as f:
@@ -63,46 +118,6 @@ def main():
 
     with open(playbook_path, 'w') as f:
         yaml.dump(playbook, f, default_flow_style=False)
-
-    # Handle attachments
-    if args.attachments.lower() == 'false':
-        # Remove attachments directory if tutorial is included
-        attachments_dir = 'Vulkan-Tutorial/antora/modules/ROOT/attachments'
-        if os.path.exists(attachments_dir):
-            print(f"Removing attachments: {attachments_dir}")
-            subprocess.run(['rm', '-rf', attachments_dir])
-    elif args.attachments.lower() == 'true':
-        # "Cleaning" it - remove known large types to save space
-        attachments_dir = 'Vulkan-Tutorial/antora/modules/ROOT/attachments'
-        if os.path.exists(attachments_dir):
-            print(f"Cleaning attachments: {attachments_dir}")
-            # Remove known large directories
-            for d in ['venv', 'node_modules', 'third_party', 'cmake-build-debug', 'build', 'lib', 'ort_gpu', 'build_integration_test', 'Assets', 'simple_engine', '__pycache__']:
-                subprocess.run(['find', attachments_dir, '-type', 'd', '-name', d, '-prune', '-exec', 'rm', '-rf', '{}', '+'])
-            # Remove any large files
-            subprocess.run(['find', attachments_dir, '-type', 'f', '(',
-                            '-name', '*.zip', '-o',
-                            '-name', '*.tar.gz', '-o',
-                            '-name', '*.pdf', '-o',
-                            '-name', '*.mp4', '-o',
-                            '-name', '*.mov', '-o',
-                            '-name', '*.whl', '-o',
-                            '-name', '*.nupkg', '-o',
-                            '-name', '*.tgz', '-o',
-                            '-name', '*.so*', '-o',
-                            '-name', '*.exe', '-o',
-                            '-name', '*.bin', '-o',
-                            '-name', '*.tar.xz', '-o',
-                            '-name', '*.onnx*', '-o',
-                            '-name', '*.pth', '-o',
-                            '-name', '*.vmfb', '-o',
-                            '-name', '*.mlir', '-o',
-                            '-name', '*.a', '-o',
-                            '-name', '*.lib', '-o',
-                            '-name', '*.dll', '-o',
-                            '-name', '*.node', '-o',
-                            '-name', '*.pyc'
-                            ')', '-delete'])
 
     # Handle image optimization
     if args.optimize.lower() == 'true':


### PR DESCRIPTION
… rewriting

- Move Antora playbook preparation after tutorial/samples setup to ensure attachments are cleaned before build
- Add GitHub Pages deployment permissions (pages:write, id-token:write)
- Replace JamesIves/github-pages-deploy-action with official GitHub Pages actions workflow
- Implement staged deployment: build full site artifact, then deduplicate PR previews
- Prune closed PR folders from gh-pages during deployment as safety net
- Preserve HTML pages in PR previews to maintain review navigation context
- Delete duplicate binary assets (images, fonts, etc.) and rewrite references to point to base site
- Clean both source and processed attachments directories to ensure Assets/assets folders are removed
- Fix copyright year typo (20206 → 2026)