### PR TITLE
Add top navbar element for Slang landing page in the guide

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -28,6 +28,7 @@
             <a class="navbar-item" href="{{siteRootPath}}/spec/latest/chapters/introduction.html">Vulkan API</a>
             <a class="navbar-item" href="{{siteRootPath}}/glsl/latest/index.html">GLSL</a>
             <a class="navbar-item" href="{{siteRootPath}}/guide/latest/hlsl.html">HLSL</a>
+            <a class="navbar-item" href="{{siteRootPath}}/guide/latest/slang.html">Slang</a>
           </div>
         </div>
         <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
*Do not merge* until
https://github.com/KhronosGroup/Vulkan-Guide/pull/373 is completed and merged.

Originally proposed in #173. That was accidentally merged, then reverted in #202.