### PR TITLE
Fix multilang script javascript.

### DIFF
--- a/multilang-README.adoc
+++ b/multilang-README.adoc
@@ -30,7 +30,7 @@ Inside a listing block, wrap each language variant with matching `START` / `END`
 // END <lang>
 ----
 
-* `<lang>` may contain letters, digits, hyphens, and underscores (`[A-Za-z0-9_-]`).
+* `<lang>` may contain letters, digits, hyphens, underscores, `+`, and `#` (`[A-Za-z0-9_+#-]`) — this covers language names like `c++` and `c#`.
 * Matching is case-insensitive for the `END` marker, but the label shown in the drop-down uses the exact capitalisation from the `START` marker.
 * Variants are displayed in the order their `START` markers appear.
 * Content outside any `START`/`END` pair is silently ignored.
@@ -100,7 +100,7 @@ Each language variant receives the CSS class `language-<lang>` (e.g. `language-C
 | `// START <lang>` … `// END <lang>`
 
 | Allowed characters in `<lang>`
-| `A-Z a-z 0-9 _ -`
+| `A-Z a-z 0-9 _ + # -`
 
 | `localStorage` key
 | `preferredCodeLang`

--- a/src/js/20-multilang.js
+++ b/src/js/20-multilang.js
@@ -3,8 +3,8 @@
   'use strict'
 
   function parseMultilang (text) {
-    const startRe = /^\s*\/\/\s*START\s+([A-Za-z0-9_-]+)/i
-    const endRe = /^\s*\/\/\s*END\s+([A-Za-z0-9_-]+)/i
+    const startRe = /^\s*\/\/\s*START\s+([A-Za-z0-9_+#-]+)/i
+    const endRe = /^\s*\/\/\s*END\s+([A-Za-z0-9_+#-]+)/i
     const lines = text.replace(/\r\n?/g, '\n').split('\n')
     const blocks = {}
     const order = []
@@ -151,7 +151,7 @@
       var pre = code.parentNode
       // only process if language is marked as multilang or content contains markers
       var isMulti = (code.getAttribute('data-lang') || '').toLowerCase() === 'multilang' ||
-        /\n\s*\/\/\s*START\s+[A-Za-z0-9_-]+/i.test(code.textContent)
+        /\n\s*\/\/\s*START\s+[A-Za-z0-9_+#-]+/i.test(code.textContent)
       if (!isMulti) return
       try { enhanceMultilangBlock(pre, code) } catch (e) { /* fail-safe */ }
     })

--- a/src/js/20-multilang.js
+++ b/src/js/20-multilang.js
@@ -13,16 +13,14 @@
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
-      const mStart = line.match(startRe)
+      // Only treat a START marker as a real language switch when we're not already
+      // inside a block - an ordinary comment that happens to start with "// Start ..."
+      // partway through a language's content (e.g. "// Start worker threads") must not
+      // be mistaken for a new marker, or it would swallow the real END that follows it.
+      const mStart = curr === null ? line.match(startRe) : null
       if (mStart) {
-        // flush any stray buffer (ignored)
-        if (curr && buf.length) {
-          blocks[curr] = (blocks[curr] || '') + (blocks[curr] ? '\n' : '') + buf.join('\n')
-          buf = []
-        }
         curr = mStart[1]
         if (!Object.prototype.hasOwnProperty.call(blocks, curr)) order.push(curr)
-        // reset buffer for this lang
         buf = []
         continue
       }
@@ -149,9 +147,11 @@
     var blocks = document.querySelectorAll('pre > code')
     blocks.forEach(function (code) {
       var pre = code.parentNode
-      // only process if language is marked as multilang or content contains markers
+      // only process if language is marked as multilang or content contains matching
+      // START/END marker pairs (an ordinary comment like "// Start worker threads" must
+      // not be enough on its own - it needs a "// END worker" to match, same as parseMultilang requires)
       var isMulti = (code.getAttribute('data-lang') || '').toLowerCase() === 'multilang' ||
-        /\n\s*\/\/\s*START\s+[A-Za-z0-9_+#-]+/i.test(code.textContent)
+        /\/\/\s*START\s+([A-Za-z0-9_+#-]+)[\s\S]*\/\/\s*END\s+\1\b/i.test(code.textContent)
       if (!isMulti) return
       try { enhanceMultilangBlock(pre, code) } catch (e) { /* fail-safe */ }
     })


### PR DESCRIPTION
- `src/js/20-multilang.js`'s 
START/END marker regex (`[A-Za-z0-9_-]+`) didn't allow `+`, 
so `// START c++` was silently truncated to `// START c`
