### PR TITLE
Fix .no-invert role not working on Asciidoctor image blocks

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1086,6 +1086,17 @@
   width: 1.5em;
 }
 
-:root.dark img[src$=".svg"] {
+:root.dark img[src$=".svg"]:not(.no-invert) {
   filter: invert(1);
+}
+
+/*
+ * Asciidoctor puts a block image's `role` attribute on the wrapping
+ * .imageblock div, not on the <img> itself, so an image marked
+ * `image::foo.svg[role=no-invert]` needs this descendant selector -
+ * the :not(.no-invert) rule above only covers roles/classes applied
+ * directly to an <img> (e.g. in raw HTML or UI templates).
+ */
+:root.dark .no-invert img[src$=".svg"] {
+  filter: none;
 }


### PR DESCRIPTION
Fixes an issue reported in KhronosGroup/Vulkan-Tutorial#111 (a pipeline diagram's colors are described in the surrounding text but get flipped by dark-mode inversion). Verified against a build of Vulkan-Tutorial with `role=no-invert` added to that image — colors are now correct in both light and dark mode.