### PR TITLE
Fix broken REUSE.toml path for antora-static-nav

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -39,7 +39,7 @@ SPDX-License-Identifier = "CC-BY-4.0"
 
 # Holochip antora extensions
 [[annotations]]
-path = ["docs-site/extnesions/antora-static-nav/lib/index.js", "docs-site/extnesions/antora-static-nav/test/integration.test.js", "docs-site/extnesions/antora-static-nav/test/unit.test.js", "docs-site/extnesions/antora-static-nav/package.json"]
+path = ["docs-site/extensions/antora-static-nav/lib/index.js", "docs-site/extensions/antora-static-nav/test/integration.test.js", "docs-site/extensions/antora-static-nav/test/unit.test.js", "docs-site/extensions/antora-static-nav/package.json"]
 precedence = "closest"
 SPDX-FileCopyrightText = "Copyright 2026 Holochip Inc."
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
REUSE.toml pointed at a misspelled, nonexistent path.

Part of #201.